### PR TITLE
Copy `primitive-math` into `clj-commons.primitive-math`

### DIFF
--- a/src/clj_commons/primitive_math.clj
+++ b/src/clj_commons/primitive_math.clj
@@ -1,0 +1,326 @@
+(ns clj-commons.primitive-math
+  (:refer-clojure
+    :exclude [* + - / < > <= >= == rem bit-or bit-and bit-xor bit-not bit-shift-left bit-shift-right unsigned-bit-shift-right byte short int float long double inc dec zero? min max true? false?])
+  (:import
+    [clj_commons.primitive_math Primitives]
+    [java.nio ByteBuffer]))
+
+;;;
+
+(defmacro ^:private variadic-proxy
+  "Creates left-associative variadic forms for any operator."
+  ([name fn]
+     `(variadic-proxy ~name ~fn ~(str "A primitive macro version of `" name "`")))
+  ([name fn doc]
+     `(variadic-proxy ~name ~fn ~doc identity))
+  ([name fn doc single-arg-form]
+     (let [x-sym (gensym "x")]
+       `(defmacro ~name
+          ~doc
+          ([~x-sym]
+             ~((eval single-arg-form) x-sym))
+          ([x# y#]
+             (list '~fn x# y#))
+          ([x# y# ~'& rest#]
+             (list* '~name (list '~name x# y#) rest#))))))
+
+(defmacro ^:private variadic-predicate-proxy
+  "Turns variadic predicates into multiple pair-wise comparisons."
+  ([name fn]
+     `(variadic-predicate-proxy ~name ~fn ~(str "A primitive macro version of `" name "`")))
+  ([name fn doc]
+     `(variadic-predicate-proxy ~name ~fn ~doc (constantly true)))
+  ([name fn doc single-arg-form]
+     (let [x-sym (gensym "x")]
+       `(defmacro ~name
+          ~doc
+          ([~x-sym]
+             ~((eval single-arg-form) x-sym))
+          ([x# y#]
+             (list '~fn x# y#))
+          ([x# y# ~'& rest#]
+             (list 'clj_commons.primitive_math.Primitives/and (list '~name x# y#) (list* '~name y# rest#)))))))
+
+(variadic-proxy +             clj_commons.primitive_math.Primitives/add)
+(variadic-proxy -             clj_commons.primitive_math.Primitives/subtract "A primitive macro version of `-`" (fn [x] `(list 'clj_commons.primitive_math.Primitives/negate ~x)))
+(variadic-proxy *             clj_commons.primitive_math.Primitives/multiply)
+(variadic-proxy /             clj_commons.primitive_math.Primitives/divide)
+(variadic-proxy div           clj_commons.primitive_math.Primitives/divide)
+(variadic-proxy bit-and       clj_commons.primitive_math.Primitives/bitAnd)
+(variadic-proxy bit-or        clj_commons.primitive_math.Primitives/bitOr)
+(variadic-proxy bit-xor       clj_commons.primitive_math.Primitives/bitXor)
+(variadic-proxy bool-and      clj_commons.primitive_math.Primitives/and)
+(variadic-proxy bool-or       clj_commons.primitive_math.Primitives/or)
+(variadic-proxy bool-xor      clj_commons.primitive_math.Primitives/xor)
+(variadic-proxy min           clj_commons.primitive_math.Primitives/min)
+(variadic-proxy max           clj_commons.primitive_math.Primitives/max)
+
+(variadic-predicate-proxy >   clj_commons.primitive_math.Primitives/gt)
+(variadic-predicate-proxy <   clj_commons.primitive_math.Primitives/lt)
+(variadic-predicate-proxy <=  clj_commons.primitive_math.Primitives/lte)
+(variadic-predicate-proxy >=  clj_commons.primitive_math.Primitives/gte)
+(variadic-predicate-proxy ==  clj_commons.primitive_math.Primitives/eq)
+(variadic-predicate-proxy not==  clj_commons.primitive_math.Primitives/neq "A primitive macro complement of `==`")
+
+(defmacro inc
+  "A primitive macro version of `inc`."
+  [x]
+  `(Primitives/inc ~x))
+
+(defmacro dec
+  "A primitive macro version of `dec`."
+  [x]
+  `(Primitives/dec ~x))
+
+(defmacro rem
+  "A primitive macro version of `rem`."
+  [n div]
+  `(Primitives/rem ~n ~div))
+
+(defmacro zero?
+  "A primitive macro version of `zero?`."
+  [x]
+  `(Primitives/isZero ~x))
+
+(defmacro bool-not
+  "A primitive macro version of `not`."
+  [x]
+  `(Primitives/not ~x))
+
+(defmacro bit-not
+  "A primitive macro version of `bit-not`."
+  [x]
+  `(Primitives/bitNot ~x))
+
+(defmacro true?
+  "A primitive macro version of `true?`."
+  [x]
+  `(Primitives/isTrue ~x))
+
+(defmacro false?
+  "A primitive macro version of `false?`."
+  [x]
+  `(Primitives/isFalse ~x))
+
+(defmacro bit-shift-left
+  "A primitive macro version of `bit-shift-left`."
+  [n bits]
+  `(Primitives/shiftLeft ~n ~bits))
+
+(defmacro bit-shift-right
+  "A primitive macro version of `bit-shift-right`."
+  [n bits]
+  `(Primitives/shiftRight ~n ~bits))
+
+;; this was the original name, which doesn't match the Clojure name and is kept
+;; around for legacy purposes
+(defmacro ^:no-doc bit-unsigned-shift-right
+  [n bits]
+  `(Primitives/unsignedShiftRight ~n ~bits))
+
+(defmacro unsigned-bit-shift-right
+  "A primitive macro which performs an unsigned right bit-shift."
+  [n bits]
+  `(Primitives/unsignedShiftRight ~n ~bits))
+
+(defmacro <<
+  "An alias for `bit-shift-left`."
+  [n bits]
+  `(Primitives/shiftLeft ~n ~bits))
+
+(defmacro >>
+  "An alias for `bit-shift-right`."
+  [n bits]
+  `(Primitives/shiftRight ~n ~bits))
+
+(defmacro >>>
+  "An alias for `bit-unsigned-shift-right`."
+  [n bits]
+  `(Primitives/unsignedShiftRight ~n ~bits))
+
+;;;
+
+(def ^:private vars-to-exclude
+  '[* + - / < > <= >= == rem bit-or bit-and bit-xor bit-not bit-shift-left bit-shift-right byte short int float long double inc dec zero? true? false? min max])
+
+(defn- using-primitive-operators? []
+  (= #'clj-commons.primitive-math/+ (resolve '+)))
+
+(defonce ^:private hijacked? (atom false))
+
+(defn- ns-wrapper
+  "Makes sure that if a namespace that is using primitive operators is reloaded, it will automatically
+   exclude the shadowed operators in `clojure.core`."
+  [f]
+  (fn [& x]
+    (if-not (using-primitive-operators?)
+      (apply f x)
+      (let [refer-clojure (->> x
+                            (filter #(and (sequential? %) (= :refer-clojure (first %))))
+                            first)
+            refer-clojure-clauses (update-in
+                                    (apply hash-map (rest refer-clojure))
+                                    [:exclude]
+                                    #(concat % vars-to-exclude))]
+        (apply f
+          (concat
+            (remove #{refer-clojure} x)
+            [(list* :refer-clojure (apply concat refer-clojure-clauses))]))))))
+
+(defn use-primitive-operators
+  "Replaces Clojure's arithmetic and number coercion functions with primitive equivalents.  These are
+   defined as macros, so they cannot be used as higher-order functions.  This is an idempotent operation.."
+  []
+  (when-not @hijacked?
+    (reset! hijacked? true)
+    (alter-var-root #'clojure.core/ns ns-wrapper))
+  (when-not (using-primitive-operators?)
+    (doseq [v vars-to-exclude]
+      (ns-unmap *ns* v))
+    (require (vector 'clj-commons.primitive-math :refer vars-to-exclude))))
+
+(defn unuse-primitive-operators
+  "Undoes the work of `use-primitive-operators`.  This is idempotent."
+  []
+  (doseq [v vars-to-exclude]
+    (ns-unmap *ns* v))
+  (refer 'clojure.core))
+
+;;;
+
+(defn byte
+  "Truncates a number to a byte, will not check for overflow."
+  {:inline (fn [x] `(clj_commons.primitive_math.Primitives/toByte ~x))}
+  ^long [^long x]
+  (unchecked-long (Primitives/toByte x)))
+
+(defn short
+  "Truncates a number to a short, will not check for overflow."
+  {:inline (fn [x] `(clj_commons.primitive_math.Primitives/toShort ~x))}
+  ^long [^long x]
+  (unchecked-long (Primitives/toShort x)))
+
+(defn int
+  "Truncates a number to an int, will not check for overflow."
+  {:inline (fn [x] `(clj_commons.primitive_math.Primitives/toInteger ~x))}
+  ^long [^long x]
+  (unchecked-long (Primitives/toInteger x)))
+
+(defn float
+  "Truncates a number to a float, will not check for overflow."
+    {:inline (fn [x] `(clj_commons.primitive_math.Primitives/toFloat ~x))}
+  ^double [^double x]
+  (unchecked-double (Primitives/toFloat x)))
+
+(defn long
+  "Converts a number to a long."
+  {:inline (fn [x] `(unchecked-long ~x))}
+  ^long [x]
+  (unchecked-long x))
+
+(defn double
+  "Converts a number to a double."
+  {:inline (fn [x] `(unchecked-double ~x))}
+  ^double [x]
+  (unchecked-double x))
+
+(defn byte->ubyte
+  "Converts a byte to an unsigned byte."
+  {:inline (fn [x] `(->> ~x long (bit-and 0xFF) short))}
+  ^long [^long x]
+  (long (short (bit-and x 0xFF))))
+
+(defn ubyte->byte
+  "Converts an unsigned byte to a byte."
+  {:inline (fn [x] `(byte (long ~x)))}
+  ^long [^long x]
+  (long (byte x)))
+
+(defn short->ushort
+  "Converts a short to an unsigned short."
+  {:inline (fn [x] `(->> ~x long (bit-and 0xFFFF) int))}
+  ^long [^long x]
+  (long (int (bit-and 0xFFFF x))))
+
+(defn ushort->short
+  "Converts an unsigned short to a short."
+  {:inline (fn [x] `(short (long ~x)))}
+  ^long [^long x]
+  (long (short x)))
+
+(defn int->uint
+  "Converts an integer to an unsigned integer."
+  {:inline (fn [x] `(->> ~x long (bit-and 0xFFFFFFFF)))}
+  ^long [^long x]
+  (long (bit-and 0xFFFFFFFF x)))
+
+(defn uint->int
+  "Converts an unsigned integer to an integer."
+  {:inline (fn [x] `(int (long ~x)))}
+  ^long [^long x]
+  (long (int x)))
+
+(defn long->ulong
+  "Converts a long to an unsigned long."
+  [^long x]
+  (BigInteger. 1
+    (-> (ByteBuffer/allocate 8) (.putLong x) .array)))
+
+(defn ^long ulong->long
+  "Converts an unsigned long to a long."
+  ^long [x]
+  (.longValue ^clojure.lang.BigInt (bigint x)))
+
+(defn float->int
+  "Converts a float to an integer."
+  {:inline (fn [x] `(Float/floatToRawIntBits (float ~x)))}
+  ^long [^double x]
+  (long (Float/floatToRawIntBits x)))
+
+(defn int->float
+  "Converts an integer to a float."
+  {:inline (fn [x] `(Float/intBitsToFloat (int ~x)))}
+  ^double [^long x]
+  (double (Float/intBitsToFloat x)))
+
+(defn double->long
+  "Converts a double to a long."
+  {:inline (fn [x] `(Double/doubleToRawLongBits ~x))}
+  ^long [^double x]
+  (long (Double/doubleToRawLongBits x)))
+
+(defn long->double
+  "Converts a long to a double."
+  {:inline (fn [x] `(Double/longBitsToDouble ~x))}
+  ^double [^long x]
+  (double (Double/longBitsToDouble x)))
+
+(defn reverse-short
+  "Inverts the endianness of a short."
+  {:inline (fn [x] `(Primitives/reverseShort ~x))}
+  ^long [^long x]
+  (->> x Primitives/reverseShort long))
+
+(defn reverse-int
+  "Inverts the endianness of an int."
+  {:inline (fn [x] `(Primitives/reverseInteger ~x))}
+  ^long [^long x]
+  (->> x Primitives/reverseInteger long))
+
+(defn reverse-long
+  "Inverts the endianness of a long."
+  {:inline (fn [x] `(Primitives/reverseLong ~x))}
+  ^long [^long x]
+  (Primitives/reverseLong x))
+
+(defn reverse-float
+  "Inverts the endianness of a float."
+  {:inline (fn [x] `(-> ~x float->int reverse-int int->float))}
+  ^double [^double x]
+  (-> x float->int reverse-int int->float))
+
+(defn reverse-double
+  "Inverts the endianness of a double."
+  {:inline (fn [x] `(-> ~x double->long reverse-long long->double))}
+  ^double [^double x]
+  (-> x double->long reverse-long long->double))

--- a/src/clj_commons/primitive_math/Primitives.java
+++ b/src/clj_commons/primitive_math/Primitives.java
@@ -1,0 +1,302 @@
+package clj_commons.primitive_math;
+
+public class Primitives {
+
+    public static byte toByte(long n) {
+        return (byte) n;
+    }
+
+    public static short toShort(long n) {
+        return (short) n;
+    }
+
+    public static int toInteger(long n) {
+        return (int) n;
+    }
+
+    public static float toFloat(double n) {
+        return (float) n;
+    }
+
+    public static short reverseShort(long n) {
+        return (short) (((short) n << 8)
+                        | ((char) n >>> 8));
+    }
+
+    public static int reverseInteger(long n) {
+        int x = (int) n;
+        return ((x << 24)
+                | ((x & 0x0000ff00) <<  8)
+                | ((x & 0x00ff0000) >>> 8)
+                | (x >>> 24));
+    }
+
+    public static long reverseLong(long n) {
+        return (((long) reverseInteger(n) << 32)
+                | ((long) reverseInteger((n >>> 32)) & 0xffffffffL));
+    }
+
+    ////
+
+    public static boolean isTrue(boolean x) {
+        return x == true;
+    }
+
+    public static boolean isFalse(boolean x) {
+        return x == false;
+    }
+
+    public static boolean and(boolean a, boolean b) {
+        return a && b;
+    }
+
+    public static boolean or(boolean a, boolean b) {
+        return a || b;
+    }
+
+    public static boolean not(boolean a) {
+        return !a;
+    }
+
+    public static boolean xor(boolean a, boolean b) {
+        return (a || b) && !(a && b);
+    }
+
+
+    ////
+
+    public static long bitAnd(long a, long b) {
+        return a & b;
+    }
+
+    public static long bitOr(long a, long b) {
+        return a | b;
+    }
+
+    public static long bitXor(long a, long b) {
+        return a ^ b;
+    }
+
+    public static long bitNot(long a) {
+        return ~a;
+    }
+
+    public static long shiftLeft(long a, long n) {
+        return a << n;
+    }
+
+    public static long shiftRight(long a, long n) {
+        return a >> n;
+    }
+
+    public static long unsignedShiftRight(long a, long n) {
+        return a >>> n;
+    }
+
+    public static int unsignedShiftRight(int a, long n) {
+        return a >>> n;
+    }
+
+    ////
+
+    public static boolean lt(long a, long b) {
+        return a < b;
+    }
+
+    public static boolean lt(float a, float b) {
+        return a < b;
+    }
+
+    public static boolean lt(double a, double b) {
+        return a < b;
+    }
+
+    public static boolean lte(double a, double b) {
+        return a <= b;
+    }
+
+    public static boolean lte(float a, float b) {
+        return a <= b;
+    }
+
+    public static boolean lte(long a, long b) {
+        return a <= b;
+    }
+
+    public static boolean gt(long a, long b) {
+        return a > b;
+    }
+
+    public static boolean gt(float a, float b) {
+        return a > b;
+    }
+
+    public static boolean gt(double a, double b) {
+        return a > b;
+    }
+
+    public static boolean gte(long a, long b) {
+        return a >= b;
+    }
+
+    public static boolean gte(float a, float b) {
+        return a >= b;
+    }
+
+    public static boolean gte(double a, double b) {
+        return a >= b;
+    }
+
+    public static boolean eq(long a, long b) {
+        return a == b;
+    }
+
+    public static boolean eq(float a, float b) {
+        return a == b;
+    }
+
+    public static boolean eq(double a, double b) {
+        return a == b;
+    }
+
+    public static boolean neq(long a, long b) {
+        return a != b;
+    }
+
+    public static boolean neq(float a, float b) {
+        return a != b;
+    }
+
+    public static boolean neq(double a, double b) {
+        return a != b;
+    }
+
+    ////
+
+    public static long rem(long n, long div) {
+        return n % div;
+    }
+
+    public static long inc(long n) {
+        return n + 1;
+    }
+
+    public static float inc(float n) {
+        return n + 1.0f;
+    }
+
+    public static double inc(double n) {
+        return n + 1.0;
+    }
+
+    public static long dec(long n) {
+        return n - 1;
+    }
+
+    public static float dec(float n) {
+        return n - 1.0f;
+    }
+
+    public static double dec(double n) {
+        return n - 1.0;
+    }
+
+    public static boolean isZero(long n) {
+        return n == 0;
+    }
+
+    public static boolean isZero(float n) {
+        return n == 0.0f;
+    }
+
+    public static boolean isZero(double n) {
+        return n == 0.0;
+    }
+
+    public static long add(long a, long b) {
+        return a + b;
+    }
+
+    public static float add(float a, float b) {
+        return a + b;
+    }
+
+    public static double add(double a, double b) {
+        return a + b;
+    }
+
+    public static long subtract(long a, long b) {
+        return a - b;
+    }
+
+    public static float subtract(float a, float b) {
+        return a - b;
+    }
+
+    public static double subtract(double a, double b) {
+        return a - b;
+    }
+
+    public static long negate(long n) {
+        return -n;
+    }
+
+    public static float negate(float n) {
+        return -n;
+    }
+
+    public static double negate(double n) {
+        return -n;
+    }
+
+    public static long multiply(long a, long b) {
+        return a * b;
+    }
+
+    public static float multiply(float a, float b) {
+        return a * b;
+    }
+
+    public static double multiply(double a, double b) {
+        return a * b;
+    }
+
+    public static long divide(long a, long b) {
+        return a / b;
+    }
+
+    public static float divide(float a, float b) {
+        return a / b;
+    }
+
+    public static double divide(double a, double b) {
+        return a / b;
+    }
+
+    ;;;
+
+    public static long max(long a, long b) {
+        return a < b ? b : a;
+    }
+
+    public static long min(long a, long b) {
+        return a > b ? b : a;
+    }
+
+    public static float max(float a, float b) {
+        return a < b ? b : a;
+    }
+
+    public static float min(float a, float b) {
+        return a > b ? b : a;
+    }
+
+    public static double max(double a, double b) {
+        return a < b ? b : a;
+    }
+
+    public static double min(double a, double b) {
+        return a > b ? b : a;
+    }
+
+}

--- a/test/clj_commons/primitive_math_test.clj
+++ b/test/clj_commons/primitive_math_test.clj
@@ -1,0 +1,69 @@
+(ns clj-commons.primitive-math-test
+  (:use
+    clojure.test)
+  (:require
+    [clj-commons.primitive-math :as p]))
+
+(set! *warn-on-reflection* true)
+
+(def primitive-ops
+  {:long    `[p/long->ulong     p/ulong->long    p/reverse-long]
+   :int     `[p/int->uint       p/uint->int      p/reverse-int]
+   :short   `[p/short->ushort   p/ushort->short  p/reverse-short]
+   :byte    `[p/byte->ubyte     p/ubyte->byte    identity]
+   :float  ` [identity          identity         p/reverse-float]
+   :double  `[identity          identity         p/reverse-double]})
+
+(deftest test-roundtrips
+  (are [type nums]
+    (let [[s->u u->s reverse-fn] (primitive-ops type)]
+      (let [s->u' (eval s->u)
+            u->s' (eval u->s)
+            reverse-fn' (eval reverse-fn)]
+        (every?
+          (fn [x]
+            (and
+             ;; test both normal and inlined versions of the functions
+              (= x (eval `(-> ~x ~s->u ~u->s)))
+              (= x (-> x s->u' u->s'))
+              (= x (eval `(-> ~x ~reverse-fn ~reverse-fn)))
+              (= x (-> x reverse-fn' reverse-fn'))))
+          nums)))
+
+    :double [-1.0 0.0 1.0 Double/MIN_VALUE   Double/MAX_VALUE]
+    :float  [-1.0 0.0 1.0 Float/MIN_VALUE    Float/MAX_VALUE]
+    :long   [-1 0 1       Long/MIN_VALUE     Long/MAX_VALUE]
+    :int    [-1 0 1       Integer/MIN_VALUE  Integer/MAX_VALUE]
+    :short  [-1 0 1       Short/MIN_VALUE    Short/MAX_VALUE]
+    :byte   [-1 0 1       Byte/MIN_VALUE     Byte/MAX_VALUE]))
+
+(defn eval-assertions [x]
+  (eval
+    `(do
+       ~@(map #(list `is %) x))))
+
+(deftest test-arithmetic
+  (p/use-primitive-operators)
+  (try
+    (eval-assertions
+      '((== 6 (+ 1 2 3) (+ 3 3) (+ 6))
+        (== 0 (- 6 3 3) (- 6 6))
+        (== -3 (- 3))
+        (== 12 (* 2 2 3) (* 4 3))
+        (== 5 (/ 10 2) (/ 20 2 2) (/ 11 2))
+
+        (= true (and true) (and true true) (or true) (or false true))
+        (= false (and false) (or false) (and true false))
+
+        (== 6.0 (+ 1.0 2.0 3.0) (+ 3.0 3.0))
+
+        (== (float 6.0) (+ (float 1.0) (float 2.0) (float 3.0)) (+ (float 3.0) (float 3.0)))
+
+        (thrown? IllegalArgumentException
+          (+ 1 2.0))))
+    (finally
+      (p/unuse-primitive-operators)))
+
+  (eval-assertions
+    `((== 6 (+ 1 2 3) (+ 3 3))
+      (== 3.0 (+ 1 2.0)))))


### PR DESCRIPTION
Copy `primitive-math` to `primitive-math.core`

Fixes issues with single segment namespaces.
Keep existing namespaces for compatibility.


Changes:

`src/primitive_math.clj` to `src/primitive_math/core.clj`

```
$ diff src/primitive_math.clj src/primitive_math/core.clj
1c1
< (ns primitive-math
---
> (ns primitive-math.core
42c42
<              (list 'primitive_math.Primitives/and (list '~name x# y#) (list* '~name y# rest#)))))))
---
>              (list '.primitive_math.Primitives/and (list '~name x# y#) (list* '~name y# rest#)))))))
147c147
<   (= #'primitive-math/+ (resolve '+)))
---
>   (= #'primitive-math.core/+ (resolve '+)))
180c180
<     (require (vector 'primitive-math :refer vars-to-exclude))))
---
>     (require (vector 'primitive-math.core :refer vars-to-exclude))))
```

`test/primitive_math_test.clj` to `test/primitive_math/core_test.clj`

```
$ diff test/primitive_math_test.clj test/primitive_math/core_test.clj
1c1
< (ns primitive-math-test
---
> (ns primitive-math.core-test
5c5
<     [primitive-math :as p]))
---
>     [primitive-math.core :as p]))
```