### PR TITLE
Deprecate `primitive-math` namespace

### DIFF
--- a/src/primitive_math.clj
+++ b/src/primitive_math.clj
@@ -1,6 +1,7 @@
 (ns primitive-math
-  {:deprecated "1.0.0"}
-  ; "Use clj-commons.primitive-math instead."
+  {:deprecated "1.0.0"
+   :superseded-by "clj-commons.primitive-math"} 
+  "Use clj-commons.primitive-math instead."
   (:refer-clojure
     :exclude [* + - / < > <= >= == rem bit-or bit-and bit-xor bit-not bit-shift-left bit-shift-right unsigned-bit-shift-right byte short int float long double inc dec zero? min max true? false?])
   (:import

--- a/src/primitive_math.clj
+++ b/src/primitive_math.clj
@@ -1,7 +1,7 @@
 (ns primitive-math
+  "Use clj-commons.primitive-math instead."
   {:deprecated "1.0.0"
    :superseded-by "clj-commons.primitive-math"} 
-  "Use clj-commons.primitive-math instead."
   (:refer-clojure
     :exclude [* + - / < > <= >= == rem bit-or bit-and bit-xor bit-not bit-shift-left bit-shift-right unsigned-bit-shift-right byte short int float long double inc dec zero? min max true? false?])
   (:import

--- a/src/primitive_math.clj
+++ b/src/primitive_math.clj
@@ -1,4 +1,6 @@
 (ns primitive-math
+  {:deprecated "1.0.0"}
+  ; "Use clj-commons.primitive-math instead."
   (:refer-clojure
     :exclude [* + - / < > <= >= == rem bit-or bit-and bit-xor bit-not bit-shift-left bit-shift-right unsigned-bit-shift-right byte short int float long double inc dec zero? min max true? false?])
   (:import


### PR DESCRIPTION
The new clj-commons.primitive-math is preferred now. single-segment namespaces don't work with Graal, and generally frowned upon by other JVM tooling.

@borkdude is this the correct way to deprecate a namespace? I had a go with a few different versions and this way was picked up by Cursive, but clj-kondo didn't seem to warn.
