### PR TITLE
Add primitive `rem` versions for double/float

### DIFF
--- a/src/clj_commons/primitive_math.clj
+++ b/src/clj_commons/primitive_math.clj
@@ -2,8 +2,8 @@
   (:refer-clojure
     :exclude [* + - / < > <= >= == rem bit-or bit-and bit-xor bit-not bit-shift-left bit-shift-right unsigned-bit-shift-right byte short int float long double inc dec zero? min max true? false?])
   (:import
-    [clj_commons.primitive_math Primitives]
-    [java.nio ByteBuffer]))
+    (clj_commons.primitive_math Primitives)
+    (java.nio ByteBuffer)))
 
 ;;;
 

--- a/src/clj_commons/primitive_math/Primitives.java
+++ b/src/clj_commons/primitive_math/Primitives.java
@@ -177,6 +177,10 @@ public class Primitives {
         return n % div;
     }
 
+    public static float rem(float n, float div) { return n % div; }
+
+    public static double rem(double n, double div) { return n % div; }
+
     public static long inc(long n) {
         return n + 1;
     }

--- a/src/primitive_math.clj
+++ b/src/primitive_math.clj
@@ -1,7 +1,8 @@
 (ns primitive-math
   "Use clj-commons.primitive-math instead."
   {:deprecated "1.0.0"
-   :superseded-by "clj-commons.primitive-math"} 
+   :superseded-by "clj-commons.primitive-math"
+   :no-doc true}
   (:refer-clojure
     :exclude [* + - / < > <= >= == rem bit-or bit-and bit-xor bit-not bit-shift-left bit-shift-right unsigned-bit-shift-right byte short int float long double inc dec zero? min max true? false?])
   (:import

--- a/test/clj_commons/primitive_math_test.clj
+++ b/test/clj_commons/primitive_math_test.clj
@@ -59,6 +59,10 @@
 
         (== (float 6.0) (+ (float 1.0) (float 2.0) (float 3.0)) (+ (float 3.0) (float 3.0)))
 
+        (== 1 (rem 10 9))
+        (== (float 0.5) (rem (float 6.5) (float 1.5)))
+        (== 0.5 (rem 6.5 1.5))
+
         (thrown? IllegalArgumentException
           (+ 1 2.0))))
     (finally


### PR DESCRIPTION
Fixes #9 

Also turns off doc generation for old single-segment ns