### PR TITLE
Add declarations for linters

### DIFF
--- a/src/clj_commons/primitive_math.clj
+++ b/src/clj_commons/primitive_math.clj
@@ -17,6 +17,7 @@
      (let [x-sym (gensym "x")]
        `(defmacro ~name
           ~doc
+          {:arglists '([~'x] [~'x ~'y] [~'x ~'y & ~'rest])}
           ([~x-sym]
              ~((eval single-arg-form) x-sym))
           ([x# y#]
@@ -34,6 +35,7 @@
      (let [x-sym (gensym "x")]
        `(defmacro ~name
           ~doc
+          {:arglists '([~'x] [~'x ~'y] [~'x ~'y & ~'rest])}
           ([~x-sym]
              ~((eval single-arg-form) x-sym))
           ([x# y#]

--- a/src/clj_commons/primitive_math.clj
+++ b/src/clj_commons/primitive_math.clj
@@ -268,7 +268,7 @@
   (BigInteger. 1
     (-> (ByteBuffer/allocate 8) (.putLong x) .array)))
 
-(defn ^long ulong->long
+(defn ulong->long
   "Converts an unsigned long to a long."
   ^long [x]
   (.longValue ^clojure.lang.BigInt (bigint x)))

--- a/src/clj_commons/primitive_math.clj
+++ b/src/clj_commons/primitive_math.clj
@@ -5,7 +5,11 @@
     (clj_commons.primitive_math Primitives)
     (java.nio ByteBuffer)))
 
-;;;
+;; Declare the variadic-* macro operators for linters
+(declare ^:macro + ^:macro - ^:macro * ^:macro / ^:macro div ^:macro bit-and
+         ^:macro bit-or ^:macro bit-xor ^:macro bool-and ^:macro bool-or
+         ^:macro bool-xor ^:macro min ^:macro max ^:macro > ^:macro <
+         ^:macro <= ^:macro >= ^:macro == ^:macro not==)
 
 (defmacro ^:private variadic-proxy
   "Creates left-associative variadic forms for any operator."


### PR DESCRIPTION
Static linters like kondo, Cursive, and CIDER don't understand the vars defined by the `variadic-*` macros. This adds a `declare` call to signal the names being generated.

It also adds some non-macro-generated arglists, so the docs don't say things like:
```clojure
(* x1844)
(* x__1812__auto__ y__1813__auto__)
(* x__1812__auto__ y__1813__auto__ & rest__1814__auto__)
```

It also removes an extraneous type hint.